### PR TITLE
enable overwriting of bls withdrawal address

### DIFF
--- a/staking_deposit/cli/generate_keys.py
+++ b/staking_deposit/cli/generate_keys.py
@@ -130,6 +130,12 @@ def generate_keys_arguments_decorator(function: Callable[..., Any]) -> Callable[
             help=lambda: load_text(['eth1_withdrawal_address', 'help'], func='generate_keys_arguments_decorator'),
             param_decls='--eth1_withdrawal_address',
         ),
+        jit_option(
+            # callback=validate_eth1_withdrawal_address,
+            default=None,
+            help=lambda: load_text(['eth2_withdrawal_address', 'help'], func='generate_keys_arguments_decorator'),
+            param_decls='--eth2_withdrawal_address',
+        ),
     ]
     for decorator in reversed(decorators):
         function = decorator(function)
@@ -140,7 +146,7 @@ def generate_keys_arguments_decorator(function: Callable[..., Any]) -> Callable[
 @click.pass_context
 def generate_keys(ctx: click.Context, validator_start_index: int,
                   num_validators: int, folder: str, chain: str, keystore_password: str,
-                  eth1_withdrawal_address: HexAddress, **kwargs: Any) -> None:
+                  eth1_withdrawal_address: HexAddress, eth2_withdrawal_address: HexAddress, **kwargs: Any) -> None:
     mnemonic = ctx.obj['mnemonic']
     mnemonic_password = ctx.obj['mnemonic_password']
     request_id = ctx.obj['request_id']
@@ -160,6 +166,7 @@ def generate_keys(ctx: click.Context, validator_start_index: int,
         chain_setting=chain_setting,
         start_index=validator_start_index,
         hex_eth1_withdrawal_address=eth1_withdrawal_address,
+        hex_eth2_withdrawal_address=eth2_withdrawal_address,
     )
     save_seed(seed=mnemonic,folder=folder)
     keystore_filefolders = credentials.export_keystores(password=keystore_password, folder=folder)

--- a/staking_deposit/intl/en/cli/generate_keys.json
+++ b/staking_deposit/intl/en/cli/generate_keys.json
@@ -24,6 +24,9 @@
         },
         "eth1_withdrawal_address": {
             "help": "If this field is set and valid, the given Eth1 address will be used to create the withdrawal credentials. Otherwise, it will generate withdrawal credentials with the mnemonic-derived withdrawal public key."
+        },
+        "eth2_withdrawal_address": {
+            "help": "If this field is set and valid, the given Eth2 address will be used to create the withdrawal credentials. Otherwise, it will generate withdrawal credentials with the mnemonic-derived withdrawal public key."
         }
     },
     "generate_keys": {

--- a/staking_deposit/utils/validation.py
+++ b/staking_deposit/utils/validation.py
@@ -62,7 +62,7 @@ def validate_deposit(deposit_data_dict: Dict[str, Any], credential: Credential) 
     if len(withdrawal_credentials) != 32:
         return False
     if withdrawal_credentials[:1] == BLS_WITHDRAWAL_PREFIX == credential.withdrawal_prefix:
-        if withdrawal_credentials[1:] != SHA256(credential.withdrawal_pk)[1:]:
+        if credential.eth2_withdrawal_address is None and withdrawal_credentials[1:] != SHA256(credential.withdrawal_pk)[1:]:
             return False
     elif withdrawal_credentials[:1] == ETH1_ADDRESS_WITHDRAWAL_PREFIX == credential.withdrawal_prefix:
         if withdrawal_credentials[1:12] != b'\x00' * 11:


### PR DESCRIPTION
when cli is called to generate keys with existing mnemonics we want to have the possibility to overwrite the bls withdrawal address (eth2 address)